### PR TITLE
Fixed Card effect

### DIFF
--- a/scripts/LIOV-JP/c101104061.lua
+++ b/scripts/LIOV-JP/c101104061.lua
@@ -1,4 +1,4 @@
---ユウ－Ai－
+--ユウーAiー
 --You & A.I.
 --Scripted by Kohana Sonogami
 function c101104061.initial_effect(c)
@@ -44,20 +44,21 @@ function c101104061.initial_effect(c)
 	e4:SetOperation(c101104061.attrop3)
 	c:RegisterEffect(e4)
 end
-function c101104061.filter(c,att)
-	return c:GetBaseAttack()==2300 and c:IsRace(RACE_CYBERSE) and c:IsAttribute(att)
+function c101104061.filter(c,tp,att)
+	return c:GetAttack()==2300 and c:IsRace(RACE_CYBERSE) and c:IsAttribute(att)
 end
 function c101104061.attrcon1(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c101104061.filter,1,nil,ATTRIBUTE_EARTH+ATTRIBUTE_WATER)
+	return eg:IsExists(c101104061.filter,1,nil,tp,ATTRIBUTE_WIND+ATTRIBUTE_LIGHT)
+end
+function c101104061.cfilter(c)
+	return c:IsFaceup()
 end
 function c101104061.attrtg1(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(aux.nzatk,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c101104061.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 end
 function c101104061.attrop1(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectMatchingCard(tp,aux.nzatk,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	if #g==0 then return end
+	local g=Duel.SelectMatchingCard(tp,c101104061.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.HintSelection(g)
 	local tc=g:GetFirst()
 	local e1=Effect.CreateEffect(c)
@@ -68,7 +69,7 @@ function c101104061.attrop1(e,tp,eg,ep,ev,re,r,rp)
 	tc:RegisterEffect(e1)
 end
 function c101104061.attrcon2(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c101104061.filter,1,nil,ATTRIBUTE_WIND+ATTRIBUTE_LIGHT)
+	return eg:IsExists(c101104061.filter,1,nil,tp,ATTRIBUTE_EARTH+ATTRIBUTE_WATER)
 end
 function c101104061.attrtg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.disfilter1,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
@@ -76,9 +77,7 @@ function c101104061.attrtg2(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c101104061.attrop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DISABLE)
 	local g=Duel.SelectMatchingCard(tp,aux.disfilter1,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
-	if #g==0 then return end
 	Duel.HintSelection(g)
 	local tc=g:GetFirst()
 	Duel.NegateRelatedChain(tc,RESET_TURN_SET)
@@ -95,7 +94,7 @@ function c101104061.attrop2(e,tp,eg,ep,ev,re,r,rp)
 	tc:RegisterEffect(e2)
 end
 function c101104061.attrcon3(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c101104061.filter,1,nil,ATTRIBUTE_FIRE+ATTRIBUTE_DARK)
+	return eg:IsExists(c101104061.filter,1,nil,tp,ATTRIBUTE_FIRE+ATTRIBUTE_DARK)
 end
 function c101104061.attrtg3(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -104,8 +103,6 @@ function c101104061.attrtg3(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,tp,0)
 end
 function c101104061.attrop3(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
-		or not Duel.IsPlayerCanSpecialSummonMonster(tp,11738490,0,0x4011,0,0,1,RACE_CYBERSE,ATTRIBUTE_DARK) then return end
-	local token=Duel.CreateToken(tp,101104161)
+	local token=Duel.CreateToken(tp,11738490)
 	Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
 end


### PR DESCRIPTION
this should work for both sides of the field
LIOV-JP061 Yuu-Ai- / You & A.I.
Continuous Spell Card
(1) If a Cyberse monster(s) with 2300 original ATK is Special Summoned: You can activate 1 of these effects based on the Attributes among the Summoned monsters. You can only activate each of the following effects of “You & A.I.” once per turn per Attribute.
● EARTH or WATER: Halve the ATK of 1 face-up monster "on the field", until the end of this turn.
● WIND or LIGHT: Negate the effects of 1 face-up card "on the field" until the end of this turn.
● FIRE or DARK: Special Summon 1 “@Ignister Token” (Cyberse/DARK/Level 1/ATK 0/DEF 0).